### PR TITLE
fix: `pivotal-cf/om` is in a non-standard location

### DIFF
--- a/workstation-setup/Brewfile
+++ b/workstation-setup/Brewfile
@@ -213,6 +213,7 @@ tap 'vmware-tanzu/carvel'
   # BOSH command-line interface
   brew 'bosh-cli'
   # CLI to configure and deploy tiles to Ops-Manager
+  tap 'pivotal-cf/om', 'https://github.com/pivotal-cf/om'
   brew 'pivotal-cf/om/om'
 ### }}}
 


### PR DESCRIPTION
```
Warning: 'pivotal-cf/om/om' formula is unreadable: No available formula with the name "pivotal-cf/om/om".
Please tap it and then try again: brew tap pivotal-cf/om
==> Tapping pivotal-cf/om
Cloning into '/usr/local/Homebrew/Library/Taps/pivotal-cf/homebrew-om'...
remote: Repository not found.
fatal: repository 'https://github.com/pivotal-cf/homebrew-om/' not found
Error: Failure while executing; `git clone https://github.com/pivotal-cf/homebrew-om /usr/local/Homebrew/Library/Taps/pivotal-cf/homebrew-om --origin=origin` exited with 128.
Installing pivotal-cf/om/om has failed!
```